### PR TITLE
Remove slack token

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -7,7 +7,7 @@ var controller = Botkit.slackbot({
 });
 
 var bot = controller.spawn({
-  token: 'xoxb-17631927873-ZGQL1tHrG6ErkVXNzonjPkVE'
+  token: 'REPLACE-ME'
 }).startRTM();
 
 controller.hears(['share the love'],


### PR DESCRIPTION
It has already been disabled by Slack, so no need to remove from repo's
history.